### PR TITLE
Chain dependency downloading to force reliable execution order

### DIFF
--- a/src/adapter.wrapper
+++ b/src/adapter.wrapper
@@ -15,7 +15,22 @@
   var deps = window.__karma__.dojoStart();
   deps.push("dojo/domReady!");
 
-  require(
+  // This version of "require" downloads the dependencies one at a time, waiting
+  // until the first is ready before recursing down the list. This way, the spec
+  // files are executed in a dependable order run to run, which is important to
+  // maintain a consistent test execution ordering.
+  var serialRequire = function(deps, callback) {
+    if (deps.length == 0) {
+      callback();
+    } else {
+      var nextDep = deps.shift();
+      require([nextDep], function() {
+        serialRequire(deps, callback);
+      });
+    }
+  };
+
+  serialRequire(
       deps,function(){
           window.__karma__.start();
       }


### PR DESCRIPTION
Dojo's require downloads all dependencies concurrently, and executes each as
part of finalizing it. This can cause the test specs to be processed in a
different order. If using a test framework that supports test ordering (like
jasmine), it needs the specs to come in the same order. Otherwise, the ordering
will produce different ordering, even for the same random seed.


This snagged me trying to track down a unit test failure that was order dependent. To reproduce the problem, you need to create a bunch of spec files, preferably of differing sizes, so that there's a good chance they will finish downloading in a different order than they started.